### PR TITLE
feat: allow configurable drag start mode - simple tap or long press #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Suggested change
+- Added configurable drag start mode via `TreeView.dragStartMode` - simple tap or long press.
+
 ## 0.10.1
  - Added `allowPlacement` method to the `TreeView` widget
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ class _ExampleTreeViewState extends State<ExampleTreeView> {
   Widget build(BuildContext context) {
     return TreeView(
       controller: controller,
+      dragStartMode: DragStartMode.longPress,
       nodeBuilder: (context, node) => Container(
         decoration: BoxDecoration(
           color: Theme.of(context).colorScheme.primaryContainer,
@@ -85,6 +86,7 @@ class _ExampleTreeViewState extends State<ExampleTreeView> {
 ## Features
 
 - Drag-and-drop nodes
+- Configurable drag start mode (tap or long press)
 - Expand / collapse animations
 - Controller- and node-based updates
 - Node lookup and manipulation via unique identifiers

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   fixnum:
     dependency: transitive
     description:
@@ -97,31 +97,31 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.10.1"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -219,10 +219,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.4"
   typed_data:
     dependency: transitive
     description:
@@ -243,18 +243,18 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "14.3.1"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.7.2 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/internal/node_widget.dart
+++ b/lib/src/internal/node_widget.dart
@@ -112,26 +112,44 @@ class _NodeWidgetState extends State<NodeWidget> {
                 return const SizedBox();
               }
               if (candidate.isEmpty) {
-                return widget.node.draggable
-                    ? Draggable(
-                      data: widget.node,
-                      onDragStarted: () {
-                        widget.node.isBeingDragged = true;
-                        isBeingDragged = true;
-                        widget.node.collapse();
-                      },
-                      onDragEnd: (_) => resetDrag(),
-                      onDraggableCanceled: (_, __) => resetDrag(),
-                      onDragCompleted: () => resetDrag(),
-                      feedback: Material(
-                        child: SizedBox(
-                          width: getObjectSize()?.width ?? 500,
-                          child: widget.props.itemBuilder(context, widget.node),
-                        ),
-                      ),
-                      child: widget.props.itemBuilder(context, widget.node),
-                    )
-                    : widget.props.itemBuilder(context, widget.node);
+                if (!widget.node.draggable) {
+                  return widget.props.itemBuilder(context, widget.node);
+                }
+
+                final feedback = Material(
+                  child: SizedBox(
+                    width: getObjectSize()?.width ?? 500,
+                    child: widget.props.itemBuilder(context, widget.node),
+                  ),
+                );
+
+                void handleDragStart() {
+                  widget.node.isBeingDragged = true;
+                  isBeingDragged = true;
+                  widget.node.collapse();
+                }
+
+                if (widget.props.dragStartMode == DragStartMode.longPress) {
+                  return LongPressDraggable<TreeNode>(
+                    data: widget.node,
+                    onDragStarted: handleDragStart,
+                    onDragEnd: (_) => resetDrag(),
+                    onDraggableCanceled: (_, __) => resetDrag(),
+                    onDragCompleted: () => resetDrag(),
+                    feedback: feedback,
+                    child: widget.props.itemBuilder(context, widget.node),
+                  );
+                } else {
+                  return Draggable<TreeNode>(
+                    data: widget.node,
+                    onDragStarted: handleDragStart,
+                    onDragEnd: (_) => resetDrag(),
+                    onDraggableCanceled: (_, __) => resetDrag(),
+                    onDragCompleted: () => resetDrag(),
+                    feedback: feedback,
+                    child: widget.props.itemBuilder(context, widget.node),
+                  );
+                }
               }
               return Column(
                 mainAxisSize: MainAxisSize.min,

--- a/lib/src/internal/tree_props.dart
+++ b/lib/src/internal/tree_props.dart
@@ -12,6 +12,7 @@ class TreeViewProps {
     required this.childExtent,
     required this.spacing,
     required this.animationDuration,
+    this.dragStartMode = DragStartMode.tap,
   });
 
   final TreeController controller;
@@ -29,4 +30,5 @@ class TreeViewProps {
   final double childExtent;
   final double spacing;
   final Duration animationDuration;
+  final DragStartMode dragStartMode;
 }

--- a/lib/src/treeview.dart
+++ b/lib/src/treeview.dart
@@ -3,6 +3,15 @@ import 'package:interactive_tree_view/interactive_tree_view.dart';
 import 'package:interactive_tree_view/src/internal/node_widget.dart';
 import 'package:interactive_tree_view/src/internal/tree_props.dart';
 
+///Defines how drag interactions begin inside the tree view.
+enum DragStartMode {
+  ///Start dragging as soon as a drag gesture is detected.
+  tap,
+
+  ///Require a long press before dragging starts.
+  longPress,
+}
+
 ///Indicates the placement of a node with respect to another node.
 ///
 ///Used in the [TreeView.indicatorBuilder] to indicate the placement of the indicator with respect to the given node.
@@ -33,6 +42,7 @@ class TreeView extends StatefulWidget {
     this.childExtent = 8.0,
     this.spacing = 8.0,
     this.animationDuration,
+    this.dragStartMode = DragStartMode.tap,
   });
 
   ///The controller this widget should use to build its contents.
@@ -76,6 +86,9 @@ class TreeView extends StatefulWidget {
   ///The duration of the collapse and expand animations.
   final Duration? animationDuration;
 
+  ///Defines how drag interactions should be initiated for nodes in this tree.
+  final DragStartMode dragStartMode;
+
   TreeViewProps get _props => TreeViewProps(
     controller: controller,
     itemBuilder: nodeBuilder,
@@ -85,6 +98,7 @@ class TreeView extends StatefulWidget {
     childExtent: childExtent,
     spacing: spacing,
     animationDuration: animationDuration ?? const Duration(milliseconds: 150),
+    dragStartMode: dragStartMode,
   );
 
   @override


### PR DESCRIPTION
## Summary
Currently, items in `InteractiveTreeView` can be dragged only after a simple tap. 
For some use cases, it would be useful to start drag on a **long press** instead.

This proposal adds a **configurable drag start mode**, so developers can choose between:
- `DragStartMode.tap` (default, current behaviour)
- `DragStartMode.longPress` (start drag on long press)

## Proposed API
```dart
TreeView(
  dragStartMode: DragStartMode.tap // default
  ...
)